### PR TITLE
Remove prepare script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
 		"generate": "npx vite-node src/routes/blogs/blog_list_data_generator.ts && npx vite-node src/routes/toyay/toya_files_generator.ts && npm run generate-yarn",
 		"generate-yarn": "npx vite-node src/lib/scripts/pineapple_fiber/PineappleWeaver.ts",
 		"check-requirements": "npx vite-node src/lib/scripts/SetDefaultEnvironment.ts",
-		"custom-check": "npx vite-node src/lib/scripts/util/ManualCheckRun.ts",
-		"prepare": "npm run build"
+		"custom-check": "npx vite-node src/lib/scripts/util/ManualCheckRun.ts"
 	},
 	"devDependencies": {
 		"@skeletonlabs/skeleton": "^1.2.5",


### PR DESCRIPTION
Fixes #46 

I've been having issues with my builds in a downstream package. Here's the log for it:

```
[00:33:14.645] yarn install v1.22.17
[00:33:14.707] [1/4] Resolving packages...
[00:33:14.847] [2/4] Fetching packages...
[00:33:14.856] warning Pattern ["string-width@^4.1.0"] is trying to unpack in the same destination "/vercel/.cache/yarn/v6/npm-string-width-cjs-4.2.3-269c7117d27b05ad2e536830a8ec895ef9c6d010-integrity/node_modules/string-width-cjs" as pattern ["string-width-cjs@npm:string-width@^4.2.0"]. This could result in non-deterministic behavior, skipping.
[00:33:16.833] warning package.json: "dependencies" has dependency "@sveltejs/kit" with range "^1.20.4" that collides with a dependency in "devDependencies" of the same name with version "^2.5.2"
[00:33:16.834] warning package.json: "dependencies" has dependency "svelte" with range "^4.0.0" that collides with a dependency in "devDependencies" of the same name with version "^4.2.12"
[00:33:16.864] warning @turnipxenon/pineapple@1.1.0: "dependencies" has dependency "@sveltejs/kit" with range "^1.20.4" that collides with a dependency in "devDependencies" of the same name with version "^2.5.2"
[00:33:16.864] warning @turnipxenon/pineapple@1.1.0: "dependencies" has dependency "svelte" with range "^4.0.0" that collides with a dependency in "devDependencies" of the same name with version "^4.2.12"
[00:33:16.865] [1/4] Resolving packages...
[00:33:17.000] [2/4] Fetching packages...
[00:33:17.004] warning Pattern ["string-width@^4.1.0"] is trying to unpack in the same destination "/vercel/.cache/yarn/v6/npm-string-width-cjs-4.2.3-269c7117d27b05ad2e536830a8ec895ef9c6d010-integrity/node_modules/string-width-cjs" as pattern ["string-width-cjs@npm:string-width@^4.2.0"]. This could result in non-deterministic behavior, skipping.
[00:33:17.055] error https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz: Extracting tar content of undefined failed, the file appears to be corrupt: "ENOENT: no such file or directory, chmod '/vercel/.cache/yarn/v6/npm-globrex-0.1.2-dd5d9ec826232730cd6793a5e33a9302985e6098-integrity/node_modules/globrex/readme.md'"
```

The solution might be based on this: 

Based on this find https://github.com/yarnpkg/yarn/issues/7212#issuecomment-493720324