### PR TITLE
Fix chip in light mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turnipxenon/pineapple",
   "description": "personal package for base styling for other personal projects",
-  "version": "2.4.13",
+  "version": "2.4.14",
   "scripts": {
     "dev": "vite dev",
     "build": "npm run check-requirements && vite build && yarn package",

--- a/src/lib/components/Chip.svelte
+++ b/src/lib/components/Chip.svelte
@@ -8,5 +8,6 @@
         margin: 0.25em;
         font-weight: bold;
         pointer-events: none;
+        background-color: rgb(var(--color-tertiary-500) / var(--tw-bg-opacity));
     }
 </style>


### PR DESCRIPTION
## Which issues does this affect?

- Self

## Overview

There was an issue where the chips did not follow the background color during light mode.

## Checks

- [x] If some of the checks below are deferred, link an issue for it under as a child

### Accessibility

- [x] [Changes are keyboard accessible](https://accessibility.18f.gov/keyboard/)
- [x] [All form inputs have explicit labels](https://accessibility.18f.gov/forms/)
- [x] [Page content has a meaningful heading hierarchy](https://accessibility.18f.gov/headings/)
- [x] [All relevant images use an img tag and have alt attributes](https://accessibility.18f.gov/images/)
- [x] [Text has sufficient color contrast](https://accessibility.18f.gov/color/) (a contrast ratio of 4.5:1 with the
  background)
- [x] [No red flags when running WAVE on the page](http://wave.webaim.org/)
- [x] The UI should also work in left-to-right direction

For the full list, see [18F's Accessibility Checklist](https://accessibility.18f.gov/checklist/).


<!--
References:
- https://github.com/ministryofjustice/accessibility-checklist/blob/master/README.md
-->
