### PR TITLE
Convert npm to yarn in GithubActions

### DIFF
--- a/.github/workflows/main_turnip-pineapple.yml
+++ b/.github/workflows/main_turnip-pineapple.yml
@@ -23,9 +23,8 @@ jobs:
 
       - name: npm install, build, and test
         run: |
-          npm install
-          npm run build --if-present
-          npm run test --if-present
+          yarn install
+          yarn build
 
       - name: Zip artifact for deployment
         run: zip release.zip ./* -r


### PR DESCRIPTION
## Overview

- github action is failing because it's using npm and not yarn
