### PR TITLE
Fix data-nosnippet typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turnipxenon/pineapple",
   "description": "personal package for base styling for other personal projects",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && yarn package",

--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -29,7 +29,7 @@
 </script>
 
 {#if (includeDataNoSnippet)}
-	<div class={classes} style={style} data-no-snippet>
+	<div class={classes} style={style} data-nosnippet>
 		<slot name="content" class="card" />
 	</div>
 {:else }


### PR DESCRIPTION
## Which issues does this affect?

- N/A

## Overview

- Fix typo related to data-nosnippet
- 
## Checks

- [ ] If some of the checks below are deferred, link an issue for it under as a child

### Accessibility

- [ ] [Changes are keyboard accessible](https://accessibility.18f.gov/keyboard/)
- [ ] [All form inputs have explicit labels](https://accessibility.18f.gov/forms/)
- [ ] [Page content has a meaningful heading hierarchy](https://accessibility.18f.gov/headings/)
- [ ] [All relevant images use an img tag and have alt attributes](https://accessibility.18f.gov/images/)
- [ ] [Text has sufficient color contrast](https://accessibility.18f.gov/color/) (a contrast ratio of 4.5:1 with the
  background)
- [ ] [No red flags when running WAVE on the page](http://wave.webaim.org/)
- [ ] The UI should also work in left-to-right direction

For the full list, see [18F's Accessibility Checklist](https://accessibility.18f.gov/checklist/).


<!--
References:
- https://github.com/ministryofjustice/accessibility-checklist/blob/master/README.md
-->
